### PR TITLE
Add error specially for the world when loading region

### DIFF
--- a/src/net/slipcor/pvparena/core/Config.java
+++ b/src/net/slipcor/pvparena/core/Config.java
@@ -944,7 +944,13 @@ public class Config {
         final Integer flags = parseInteger(parts[8]);
         final Integer prots = parseInteger(parts[9]);
 
-        if (Bukkit.getWorld(parts[0]) == null || x1 == null || y1 == null
+        if (Bukkit.getWorld(parts[0]) == null) {
+            PVPArena.instance.getLogger().severe(String.format("%s caused an error while loading region %s",
+                    arena.getName(), regionName));
+            throw new IllegalArgumentException(String.format("World %s not recognized. Is it loaded ?", parts[0]));
+        }
+
+        if (x1 == null || y1 == null
                 || z1 == null || x2 == null || y2 == null || z2 == null
                 || flags == null || prots == null) {
             PVPArena.instance.getLogger().severe(arena.getName() + " caused an error while loading region " + regionName);


### PR DESCRIPTION
Please NOTE:

If world is not present on server startup, the arena config file fail to load and the arena is not available.
People thinks the arena disappear and create a new arena :/

Maybe we should load the arena but disable it ? And on enable command, load the config and show the error message if error still here.