### PR TITLE
Fix discord ci notifications on multiline messages

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -44,10 +44,10 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.MVN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MVN_PASSWORD }}
-          
+
       - name: Post discord notification
         run: |
-          commits="${{ join(github.event.commits.*.message, '\n - ') }}"
+          commits=`echo "${{ join(github.event.commits.*.message, '\n - ') }}" | tr '\n' ' '`
           avatar_url=https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
           bot_username="Build notification"
           payload_json='{ "username": "'$bot_username'", "avatar_url": "'$avatar_url'", "content": "A new dev build of PVP arena is available! Download it by saving the attached file.", "embeds": [{"description": ":spiral_note_pad: **New commits:**\n\n - '$commits'"}] }'


### PR DESCRIPTION
We were 'borrowing' your discord ci notifications for use in [pvpstats](https://github.com/slipcor/PVPStats), and noticed that multiline commits will not send properly in discord:

![image](https://user-images.githubusercontent.com/3136033/108774426-9063db80-7557-11eb-8163-bbf4ece67bbc.png)

https://github.com/ffaen/pvparena/runs/1956179771?check_suite_focus=true#step:8:32

`{"message": "Cannot send an empty message", "code": 50006}`

This PR will truncate the multiline messages so that they truncate to one line

![image](https://user-images.githubusercontent.com/3136033/108774703-e46ec000-7557-11eb-8e3c-8b8836918fe4.png)

https://github.com/ffaen/pvparena/runs/1956235453?check_suite_focus=true#step:8:2