### PR TITLE
refacto: remove getName everywhere

### DIFF
--- a/src/main/java/net/slipcor/pvparena/PVPArena.java
+++ b/src/main/java/net/slipcor/pvparena/PVPArena.java
@@ -262,7 +262,7 @@ public class PVPArena extends JavaPlugin {
                 break;
             }
         }
-        final ArenaPlayer player = ArenaPlayer.parsePlayer(sender.getName());
+        final ArenaPlayer player = ArenaPlayer.fromPlayer(sender.getName());
         if (pacmd != null && !(player.getArena() != null && pacmd.hasVersionForArena())) {
             debug(sender, "committing: " + pacmd.getName());
             pacmd.commit(sender, StringParser.shiftArrayBy(args, 1));
@@ -281,8 +281,8 @@ public class PVPArena extends JavaPlugin {
 
         if (tempArena == null) {
             if (sender instanceof Player
-                    && ArenaPlayer.parsePlayer(sender.getName()).getArena() != null) {
-                tempArena = ArenaPlayer.parsePlayer(sender.getName())
+                    && ArenaPlayer.fromPlayer(sender.getName()).getArena() != null) {
+                tempArena = ArenaPlayer.fromPlayer(sender.getName())
                         .getArena();
             } else if (PAA_Setup.activeSetups.containsKey(sender.getName())) {
                 tempArena = PAA_Setup.activeSetups.get(sender.getName());

--- a/src/main/java/net/slipcor/pvparena/arena/ArenaClass.java
+++ b/src/main/java/net/slipcor/pvparena/arena/ArenaClass.java
@@ -122,7 +122,7 @@ public final class ArenaClass {
                         Bukkit.getScheduler().runTaskLater(PVPArena.getInstance(), new Runnable(){
                             @Override
                             public void run() {
-                                ArenaPlayer.parsePlayer(player.getName()).getArena().addEntity(
+                                ArenaPlayer.fromPlayer(player).getArena().addEntity(
                                         player, player.getWorld().spawnEntity(player.getLocation(), EntityType.valueOf(eggType)));
                             }
                         }, 20L);
@@ -154,7 +154,7 @@ public final class ArenaClass {
 
                 try {
                     Bukkit.getScheduler().runTaskLater(PVPArena.getInstance(), () ->
-                            ArenaPlayer.parsePlayer(player.getName()).getArena().addEntity(
+                            ArenaPlayer.fromPlayer(player).getArena().addEntity(
                                 player, player.getWorld().spawnEntity(player.getLocation(), EntityType.valueOf(eggType))), 20L);
                 } catch(final IllegalPluginAccessException ignored) {
 

--- a/src/main/java/net/slipcor/pvparena/arena/ArenaPlayer.java
+++ b/src/main/java/net/slipcor/pvparena/arena/ArenaPlayer.java
@@ -122,6 +122,7 @@ public class ArenaPlayer {
         this.player = player;
     }
 
+    @NotNull
     public Player getPlayer() {
         return this.player;
     }
@@ -186,7 +187,7 @@ public class ArenaPlayer {
      * @param player the player to supply
      */
     public static void givePlayerFightItems(final Arena arena, final Player player) {
-        final ArenaPlayer aPlayer = parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = fromPlayer(player);
 
         final ArenaClass playerClass = aPlayer.aClass;
         if (playerClass == null) {
@@ -210,7 +211,7 @@ public class ArenaPlayer {
      * @param name the playername to use
      * @return an ArenaPlayer instance belonging to that player
      */
-    public static ArenaPlayer parsePlayer(final String name) {
+    public static ArenaPlayer fromPlayer(final String name) {
         synchronized (ArenaPlayer.class) {
             Player player = Bukkit.getPlayerExact(name);
 
@@ -222,12 +223,7 @@ public class ArenaPlayer {
                 }
                 player = offlinePlayer.getPlayer();
             }
-
-            if (!totalPlayers.containsKey(player.getUniqueId())) {
-                ArenaPlayer ap = new ArenaPlayer(player);
-                totalPlayers.putIfAbsent(player.getUniqueId(), ap);
-            }
-            return totalPlayers.get(player.getUniqueId());
+            return fromPlayer(player);
         }
     }
 
@@ -246,28 +242,6 @@ public class ArenaPlayer {
     }
 
     /**
-     * add an ArenaPlayer (used to load statistics)
-     *
-     * @param player the player to use
-     * @return an ArenaPlayer instance belonging to that player
-     */
-    public static ArenaPlayer addPlayer(final Player player) {
-        synchronized (ArenaPlayer.class) {
-            ArenaPlayer aPlayer = new ArenaPlayer(player);
-            totalPlayers.putIfAbsent(player.getUniqueId(), aPlayer);
-            return totalPlayers.get(player.getUniqueId());
-        }
-    }
-
-    public static ArenaPlayer addPlayer(UUID uuid) {
-        OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(uuid);
-        if(offlinePlayer.getPlayer() == null) {
-            throw new RuntimeException(String.format("Player with uuid %s not found", uuid));
-        }
-        return addPlayer(offlinePlayer.getPlayer());
-    }
-
-    /**
      * prepare a player's inventory, back it up and clear it
      *
      * @param player the player to save
@@ -275,7 +249,7 @@ public class ArenaPlayer {
     public static void backupAndClearInventory(final Arena arena, final Player player) {
         debug(player, "saving player inventory: {}", player);
 
-        final ArenaPlayer aPlayer = parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = fromPlayer(player);
         aPlayer.savedInventory = player.getInventory().getContents().clone();
         InventoryManager.clearInventory(player);
     }
@@ -288,7 +262,7 @@ public class ArenaPlayer {
 
         debug(player, "resetting inventory");
 
-        final ArenaPlayer aPlayer = parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = fromPlayer(player);
 
         if (arena.getArenaConfig().getYamlConfiguration().get(CFG.ITEMS_TAKEOUTOFGAME.getNode()) != null) {
             final ItemStack[] items =

--- a/src/main/java/net/slipcor/pvparena/arena/ArenaTeam.java
+++ b/src/main/java/net/slipcor/pvparena/arena/ArenaTeam.java
@@ -104,7 +104,7 @@ public class ArenaTeam {
     }
 
     public boolean hasPlayer(final Player player) {
-        return this.players.contains(ArenaPlayer.parsePlayer(player.getName()));
+        return this.players.contains(ArenaPlayer.fromPlayer(player));
     }
 
     public boolean isEveryoneReady() {
@@ -123,6 +123,24 @@ public class ArenaTeam {
      */
     public void remove(final ArenaPlayer player) {
         this.players.remove(player);
+    }
+
+    /**
+     * Is a Team without any team member
+     *
+     * @return true if no team member
+     */
+    public boolean isEmpty() {
+        return this.getTeamMembers().isEmpty();
+    }
+
+    /**
+     * Is a Team with at least one team member
+     *
+     * @return true if at least one team member
+     */
+    public boolean isNotEmpty() {
+        return !this.getTeamMembers().isEmpty();
     }
 
     @Override

--- a/src/main/java/net/slipcor/pvparena/arena/PlayerState.java
+++ b/src/main/java/net/slipcor/pvparena/arena/PlayerState.java
@@ -64,7 +64,7 @@ public final class PlayerState {
         this.potionEffects = player.getActivePotionEffects();
         this.collides = player.isCollidable();
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         final Arena arena = aPlayer.getArena();
 
         aPlayer.setFlyState(player.isFlying());
@@ -92,7 +92,7 @@ public final class PlayerState {
         cfg.set("state.explevel", this.explevel);
         cfg.set("state.saturation", this.saturation);
         cfg.set("state.displayname", this.displayname);
-        cfg.set("state.flying", ArenaPlayer.parsePlayer(this.name).getFlyState());
+        cfg.set("state.flying", ArenaPlayer.fromPlayer(this.name).getFlyState());
         cfg.set("state.collides", this.collides);
     }
 
@@ -135,7 +135,7 @@ public final class PlayerState {
         PlayerState.removeEffects(player);
 
         if (arena.getArenaConfig().getBoolean(CFG.CHAT_COLORNICK)) {
-            final ArenaTeam team = ArenaPlayer.parsePlayer(player.getName()).getArenaTeam();
+            final ArenaTeam team = ArenaPlayer.fromPlayer(player).getArenaTeam();
             String n;
             if (team == null) {
                 n = player.getName();
@@ -152,7 +152,7 @@ public final class PlayerState {
         final Player player = Bukkit.getPlayerExact(this.name);
 
         if (player == null) {
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(this.name);
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(this.name);
             aPlayer.getArena().getGoal().disconnect(aPlayer);
             return;
         }
@@ -161,7 +161,7 @@ public final class PlayerState {
         player.setFireTicks(this.fireticks);
         player.setFoodLevel(this.foodlevel);
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         player.setFoodLevel(this.foodlevel);
         if (aPlayer.getArena().getArenaConfig().getGameMode(CFG.GENERAL_GAMEMODE) != null) {
             player.setGameMode(this.gamemode);
@@ -297,7 +297,7 @@ public final class PlayerState {
         pState.explevel = cfg.getInt("state.explevel", 0);
         pState.saturation = (float) cfg.getDouble("state.saturation", 0);
         pState.displayname = cfg.getString("state.displayname", pName);
-        ArenaPlayer.parsePlayer(pName).setFlyState(cfg.getBoolean("state.flying", false));
+        ArenaPlayer.fromPlayer(pName).setFlyState(cfg.getBoolean("state.flying", false));
         pState.collides = cfg.getBoolean("state.collides", false);
 
         return pState;

--- a/src/main/java/net/slipcor/pvparena/commands/PAA_Class.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAA_Class.java
@@ -59,7 +59,7 @@ public class PAA_Class extends AbstractArenaCommand {
             final Player player = (Player) sender;
             PVPArena.getInstance().getLogger().info("Exiting edit mode: " + player.getName());
 
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
             ArenaPlayer.reloadInventory(arena, player, false);
 
@@ -79,7 +79,7 @@ public class PAA_Class extends AbstractArenaCommand {
             arena.addClass(args[1], player.getInventory().getStorageContents(), player.getInventory().getItemInOffHand(), player.getInventory().getArmorContents());
             Arena.pmsg(player, Language.parse(arena, MSG.CLASS_SAVED, args[1]));
         } else if ("load".equalsIgnoreCase(args[0])) {
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(sender.getName());
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(sender.getName());
             if(aPlayer.getArenaClass() == null) {
                 ArenaPlayer.backupAndClearInventory(arena, aPlayer.getPlayer());
             } else {

--- a/src/main/java/net/slipcor/pvparena/commands/PAA_ForceWin.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAA_ForceWin.java
@@ -61,7 +61,7 @@ public class PAA_ForceWin extends AbstractArenaCommand {
             }
         } else {
             // existing player name
-            ArenaPlayer aplayer = ArenaPlayer.parsePlayer(args[0]);
+            ArenaPlayer aplayer = ArenaPlayer.fromPlayer(args[0]);
             if (!arena.equals(aplayer.getArena())) {
                 arena.msg(sender, Language.parse(MSG.ERROR_PLAYER_NOTFOUND, args[0]));
                 return;

--- a/src/main/java/net/slipcor/pvparena/commands/PAA_PlayerClass.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAA_PlayerClass.java
@@ -86,7 +86,7 @@ public class PAA_PlayerClass extends AbstractArenaCommand {
     private void reset(final Player player) {
         PVPArena.getInstance().getLogger().info("Exiting edit mode: " + player.getName());
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
         aPlayer.setArena(null);
     }

--- a/src/main/java/net/slipcor/pvparena/commands/PAA_Region.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAA_Region.java
@@ -109,7 +109,7 @@ public class PAA_Region extends AbstractArenaCommand {
         if (args.length < 3) {
             // usage: /pa {arenaname} region [regionname] {regionshape} | save selected region
 
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(sender.getName());
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(sender.getName());
 
             if (!aPlayer.didValidSelection()) {
                 arena.msg(sender, Language.parse(arena, MSG.REGION_SELECT, arena.getName()));

--- a/src/main/java/net/slipcor/pvparena/commands/PAA_Spawn.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAA_Spawn.java
@@ -57,7 +57,7 @@ public class PAA_Spawn extends AbstractArenaCommand {
         if (args.length < 2) {
             // usage: /pa {arenaname} spawn [spawnname] | set a spawn
 
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(sender.getName());
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(sender.getName());
 
             if (spawns.contains(args[0])) {
                 this.commitSet(arena, sender, new PALocation(aPlayer.getPlayer().getLocation()), args[0]);

--- a/src/main/java/net/slipcor/pvparena/commands/PAG_Arenaclass.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAG_Arenaclass.java
@@ -65,7 +65,7 @@ public class PAG_Arenaclass extends AbstractArenaCommand {
             return;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(sender.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(sender.getName());
 
         // Player can change arena class only in lounge or with ingameClassSwith parameter set to true
         if(aPlayer.getStatus() != LOUNGE && !arena.getArenaConfig().getBoolean(CFG.USES_INGAMECLASSSWITCH)) {

--- a/src/main/java/net/slipcor/pvparena/commands/PAG_Chat.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAG_Chat.java
@@ -44,7 +44,7 @@ public class PAG_Chat extends AbstractArenaCommand {
             return;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(sender.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(sender.getName());
 
         if (args.length < 1) {
             // toggle

--- a/src/main/java/net/slipcor/pvparena/commands/PAG_Join.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAG_Join.java
@@ -79,7 +79,7 @@ public class PAG_Join extends AbstractArenaCommand {
             return;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(sender.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(sender.getName());
 
         if (aPlayer.getArena() == null) {
             if (!arena.getArenaConfig().getBoolean(CFG.PERMS_ALWAYSJOININBATTLE) &&

--- a/src/main/java/net/slipcor/pvparena/commands/PAG_Leave.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAG_Leave.java
@@ -44,7 +44,7 @@ public class PAG_Leave extends AbstractArenaCommand {
             return;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(sender.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(sender.getName());
 
         // Handle modules which need to leave even if players aren't in an arena
         for (final ArenaModule mod : arena.getMods()) {

--- a/src/main/java/net/slipcor/pvparena/commands/PAI_Ready.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAI_Ready.java
@@ -43,7 +43,7 @@ public class PAI_Ready extends AbstractArenaCommand {
             return;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(sender.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(sender.getName());
 
         if (!arena.hasPlayer(aPlayer.getPlayer())) {
 

--- a/src/main/java/net/slipcor/pvparena/commands/PAI_Shutup.java
+++ b/src/main/java/net/slipcor/pvparena/commands/PAI_Shutup.java
@@ -42,7 +42,7 @@ public class PAI_Shutup extends AbstractArenaCommand {
             return;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(sender.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(sender.getName());
 
         if (args.length < 1) {
             // toggle

--- a/src/main/java/net/slipcor/pvparena/config/Debugger.java
+++ b/src/main/java/net/slipcor/pvparena/config/Debugger.java
@@ -59,7 +59,7 @@ public class Debugger {
     public static void debug(CommandSender sender, String string) {
         if (active) {
             if (sender instanceof Player) {
-                ArenaPlayer ap = ArenaPlayer.parsePlayer(sender.getName());
+                ArenaPlayer ap = ArenaPlayer.fromPlayer(sender.getName());
                 if (ap.getArena() != null) {
                     formatAndPrint(ap.getArena(), ap.getPlayer(), FINE, string);
                     return;

--- a/src/main/java/net/slipcor/pvparena/core/CollectionUtils.java
+++ b/src/main/java/net/slipcor/pvparena/core/CollectionUtils.java
@@ -1,0 +1,18 @@
+package net.slipcor.pvparena.core;
+
+import java.util.Collection;
+
+/**
+ * Utility class for collections
+ */
+public class CollectionUtils {
+
+    private CollectionUtils() {
+        // Static class can not be instantiate
+    }
+
+    public static boolean isNotEmpty(Collection<?> collection){
+        return collection != null && !collection.isEmpty();
+    }
+
+}

--- a/src/main/java/net/slipcor/pvparena/goals/AbstractTeamKillGoal.java
+++ b/src/main/java/net/slipcor/pvparena/goals/AbstractTeamKillGoal.java
@@ -25,7 +25,7 @@ import java.util.Set;
 import static net.slipcor.pvparena.config.Debugger.debug;
 
 public abstract class AbstractTeamKillGoal extends ArenaGoal {
-    public AbstractTeamKillGoal(String name) {
+    protected AbstractTeamKillGoal(String name) {
         super(name);
     }
 
@@ -94,8 +94,8 @@ public abstract class AbstractTeamKillGoal extends ArenaGoal {
     }
 
     @Override
-    public int getLives(ArenaPlayer aPlayer) {
-        return this.getScore(aPlayer.getArenaTeam());
+    public int getLives(ArenaPlayer arenaPlayer) {
+        return this.getScore(arenaPlayer.getArenaTeam());
     }
 
     @Override
@@ -119,7 +119,7 @@ public abstract class AbstractTeamKillGoal extends ArenaGoal {
 
     @Override
     public void initiate(final Player player) {
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         this.updateLives(aPlayer.getArenaTeam(), this.getTeamLivesCfg());
     }
 
@@ -130,7 +130,7 @@ public abstract class AbstractTeamKillGoal extends ArenaGoal {
 
     @Override
     public void reset(final boolean force) {
-        this.getLifeMap().clear();
+        this.getTeamLifeMap().clear();
     }
 
     @Override

--- a/src/main/java/net/slipcor/pvparena/goals/GoalSabotage.java
+++ b/src/main/java/net/slipcor/pvparena/goals/GoalSabotage.java
@@ -75,7 +75,7 @@ public class GoalSabotage extends ArenaGoal {
     }
 
     @Override
-    public List<String> getMain() {
+    public List<String> getGoalCommands() {
         final List<String> result = new ArrayList<>();
         if (this.arena != null) {
             for (final ArenaTeam team : this.arena.getTeams()) {
@@ -122,7 +122,7 @@ public class GoalSabotage extends ArenaGoal {
             return false;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player.getName());
 
         final ArenaTeam pTeam = aPlayer.getArenaTeam();
         if (pTeam == null) {
@@ -392,7 +392,7 @@ public class GoalSabotage extends ArenaGoal {
 
     @Override
     public void initiate(final Player player) {
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player.getName());
         final ArenaTeam team = aPlayer.getArenaTeam();
         this.takeFlag(team.getName(), false,
                 SpawnManager.getBlockByExactName(this.arena, team.getName() + "tnt"));
@@ -408,7 +408,7 @@ public class GoalSabotage extends ArenaGoal {
         final String teamName = this.getHeldFlagTeam(player);
         final ArenaTeam team = this.arena.getTeam(teamName);
         if (teamName != null && team != null) {
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player.getName());
             this.getFlagMap().remove(teamName);
             this.distributeFlag(aPlayer, team);
         }
@@ -473,7 +473,7 @@ public class GoalSabotage extends ArenaGoal {
 
     @Override
     public void unload(final Player player) {
-        this.disconnect(ArenaPlayer.parsePlayer(player.getName()));
+        this.disconnect(ArenaPlayer.fromPlayer(player.getName()));
     }
 
     @Override

--- a/src/main/java/net/slipcor/pvparena/goals/GoalTeamDeathConfirm.java
+++ b/src/main/java/net/slipcor/pvparena/goals/GoalTeamDeathConfirm.java
@@ -50,7 +50,7 @@ public class GoalTeamDeathConfirm extends AbstractTeamKillGoal {
 
     @Override
     protected int getScore(ArenaTeam team) {
-        return this.getTeamLivesCfg() - (this.getLifeMap().getOrDefault(team.getName(), 0));
+        return this.getTeamLivesCfg() - (this.getTeamLifeMap().getOrDefault(team, 0));
     }
 
     @Override
@@ -80,7 +80,7 @@ public class GoalTeamDeathConfirm extends AbstractTeamKillGoal {
         }
 
 
-        final ArenaTeam respawnTeam = ArenaPlayer.parsePlayer(respawnPlayer.getName()).getArenaTeam();
+        final ArenaTeam respawnTeam = ArenaPlayer.fromPlayer(respawnPlayer.getName()).getArenaTeam();
 
         this.drop(respawnPlayer, respawnTeam);
 
@@ -97,7 +97,7 @@ public class GoalTeamDeathConfirm extends AbstractTeamKillGoal {
             returned = new ArrayList<>(event.getDrops());
         }
 
-        WorkflowManager.handleRespawn(this.arena, ArenaPlayer.parsePlayer(respawnPlayer.getName()), returned);
+        WorkflowManager.handleRespawn(this.arena, ArenaPlayer.fromPlayer(respawnPlayer.getName()), returned);
     }
 
     private void drop(final Player player, final ArenaTeam team) {
@@ -118,7 +118,7 @@ public class GoalTeamDeathConfirm extends AbstractTeamKillGoal {
 
         final Material check = this.arena.getArenaConfig().getMaterial(CFG.GOAL_TDC_ITEM);
 
-        final ArenaPlayer player = ArenaPlayer.parsePlayer(event.getEntity().getName());
+        final ArenaPlayer player = ArenaPlayer.fromPlayer(event.getEntity().getName());
 
         if (item.getType().equals(check) && item.hasItemMeta()) {
             for (final ArenaTeam team : this.arena.getTeams()) {
@@ -150,14 +150,14 @@ public class GoalTeamDeathConfirm extends AbstractTeamKillGoal {
      * @return true if the player should not respawn but be removed
      */
     private boolean reduceLives(final Arena arena, final ArenaTeam team) {
-        final int iLives = this.getLifeMap().get(team.getName());
+        final int iLives = this.getTeamLifeMap().get(team);
 
         if (iLives <= 1) {
             for (final ArenaTeam otherTeam : arena.getTeams()) {
                 if (otherTeam.equals(team)) {
                     continue;
                 }
-                this.getLifeMap().remove(otherTeam.getName());
+                this.getTeamLifeMap().remove(otherTeam);
                 for (final ArenaPlayer ap : otherTeam.getTeamMembers()) {
                     if (ap.getStatus() == Status.FIGHT) {
                         ap.setStatus(Status.LOST);
@@ -169,7 +169,7 @@ public class GoalTeamDeathConfirm extends AbstractTeamKillGoal {
         }
         arena.broadcast(Language.parse(arena, MSG.GOAL_TEAMDEATHCONFIRM_REMAINING, String.valueOf(iLives - 1), team.getColoredName()));
 
-        this.getLifeMap().put(team.getName(), iLives - 1);
+        this.getTeamLifeMap().put(team, iLives - 1);
         arena.updateScoreboards();
         return false;
     }
@@ -177,7 +177,7 @@ public class GoalTeamDeathConfirm extends AbstractTeamKillGoal {
     @Override
     public void unload(final Player player) {
         if (this.allowsJoinInBattle()) {
-            this.arena.hasNotPlayed(ArenaPlayer.parsePlayer(player.getName()));
+            this.arena.hasNotPlayed(ArenaPlayer.fromPlayer(player));
         }
     }
 }

--- a/src/main/java/net/slipcor/pvparena/goals/GoalTeamLives.java
+++ b/src/main/java/net/slipcor/pvparena/goals/GoalTeamLives.java
@@ -44,7 +44,7 @@ public class GoalTeamLives extends AbstractTeamKillGoal {
 
     @Override
     protected int getScore(ArenaTeam team) {
-        return this.getLifeMap().getOrDefault(team.getName(), 0);
+        return this.getTeamLifeMap().getOrDefault(team, 0);
     }
 
     @Override
@@ -54,7 +54,7 @@ public class GoalTeamLives extends AbstractTeamKillGoal {
 
     @Override
     public Boolean checkPlayerDeath(Player player) {
-        final ArenaTeam respawnTeam = ArenaPlayer.parsePlayer(player.getName()).getArenaTeam();
+        final ArenaTeam respawnTeam = ArenaPlayer.fromPlayer(player).getArenaTeam();
 
         if (this.getTeamLives(respawnTeam) != null) {
             return true;
@@ -73,7 +73,7 @@ public class GoalTeamLives extends AbstractTeamKillGoal {
         }
         Bukkit.getPluginManager().callEvent(gEvent);
 
-        final ArenaTeam respawnTeam = ArenaPlayer.parsePlayer(respawnPlayer.getName()).getArenaTeam();
+        final ArenaTeam respawnTeam = ArenaPlayer.fromPlayer(respawnPlayer.getName()).getArenaTeam();
         this.reduceLives(this.arena, respawnTeam);
 
         if (this.getTeamLives(respawnTeam) != null) {
@@ -97,21 +97,21 @@ public class GoalTeamLives extends AbstractTeamKillGoal {
             }
 
             WorkflowManager.handleRespawn(this.arena,
-                    ArenaPlayer.parsePlayer(respawnPlayer.getName()), returned);
+                    ArenaPlayer.fromPlayer(respawnPlayer.getName()), returned);
 
         } else if (this.arena.getArenaConfig().getBoolean(CFG.PLAYER_PREVENTDEATH)) {
             debug(this.arena, respawnPlayer, "faking player death");
-            ArenaPlayer.parsePlayer(respawnPlayer.getName()).setStatus(Status.LOST);
+            ArenaPlayer.fromPlayer(respawnPlayer.getName()).setStatus(Status.LOST);
             PlayerListener.finallyKillPlayer(this.arena, respawnPlayer, event);
         }
     }
 
-    private void reduceLives(final Arena arena, final ArenaTeam team) {
-        final int iLives = this.getTeamLives(team);
+    private void reduceLives(final Arena arena, final ArenaTeam arenaTeam) {
+        final int iLives = this.getTeamLives(arenaTeam);
 
         if (iLives <= 1) {
-            this.getLifeMap().remove(team.getName());
-            for (final ArenaPlayer ap : team.getTeamMembers()) {
+            this.getTeamLifeMap().remove(arenaTeam);
+            for (final ArenaPlayer ap : arenaTeam.getTeamMembers()) {
                 if (ap.getStatus() == Status.FIGHT) {
                     ap.setStatus(Status.LOST);
                 }
@@ -120,10 +120,10 @@ public class GoalTeamLives extends AbstractTeamKillGoal {
             return;
         }
 
-        this.getLifeMap().put(team.getName(), iLives - 1);
+        this.getTeamLifeMap().put(arenaTeam, iLives - 1);
     }
 
     private Integer getTeamLives(ArenaTeam respawnTeam) {
-        return this.getLifeMap().get(respawnTeam.getName());
+        return this.getTeamLifeMap().get(respawnTeam);
     }
 }

--- a/src/main/java/net/slipcor/pvparena/listeners/BlockListener.java
+++ b/src/main/java/net/slipcor/pvparena/listeners/BlockListener.java
@@ -86,7 +86,7 @@ public class BlockListener implements Listener {
         if (event instanceof PlayerEvent) {
             final PlayerEvent e = (PlayerEvent) event;
 
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(e.getPlayer().getName());
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(e.getPlayer().getName());
 
             if (aPlayer.getArena() != null && aPlayer.getArena() != arena) {
                 return false; // players in arenas should be caught by their arenas
@@ -108,10 +108,10 @@ public class BlockListener implements Listener {
             return;
         }
 
-        if (ArenaPlayer.parsePlayer(event.getPlayer().getName()).getStatus() == Status.LOST
-                || ArenaPlayer.parsePlayer(event.getPlayer().getName()).getStatus() == Status.WATCH
-                || ArenaPlayer.parsePlayer(event.getPlayer().getName()).getStatus() == Status.LOUNGE
-                || ArenaPlayer.parsePlayer(event.getPlayer().getName()).getStatus() == Status.READY) {
+        if (ArenaPlayer.fromPlayer(event.getPlayer().getName()).getStatus() == Status.LOST
+                || ArenaPlayer.fromPlayer(event.getPlayer().getName()).getStatus() == Status.WATCH
+                || ArenaPlayer.fromPlayer(event.getPlayer().getName()).getStatus() == Status.LOUNGE
+                || ArenaPlayer.fromPlayer(event.getPlayer().getName()).getStatus() == Status.READY) {
             event.setCancelled(true);
             return;
         }
@@ -404,7 +404,7 @@ public class BlockListener implements Listener {
             return;
         }
 
-        final ArenaPlayer arenaPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer arenaPlayer = ArenaPlayer.fromPlayer(player);
         if (asList(Status.LOST, Status.WATCH, Status.LOUNGE, Status.READY).contains(arenaPlayer.getStatus())) {
             event.setCancelled(true);
             return;

--- a/src/main/java/net/slipcor/pvparena/listeners/EntityListener.java
+++ b/src/main/java/net/slipcor/pvparena/listeners/EntityListener.java
@@ -137,7 +137,7 @@ public class EntityListener implements Listener {
         if ((!(entity instanceof Player))) {
             return; // no player
         }
-        final Arena arena = ArenaPlayer.parsePlayer(entity.getName())
+        final Arena arena = ArenaPlayer.fromPlayer(entity.getName())
                 .getArena();
         if (arena == null) {
             return;
@@ -149,7 +149,7 @@ public class EntityListener implements Listener {
             return;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         final ArenaTeam team = aPlayer.getArenaTeam();
 
         if (team == null) {
@@ -188,7 +188,7 @@ public class EntityListener implements Listener {
             debug("=> {}", eDamager);
         }
 
-        if (eDamager instanceof Player && ArenaPlayer.parsePlayer(eDamager.getName()).getStatus() == Status.LOST) {
+        if (eDamager instanceof Player && ArenaPlayer.fromPlayer(eDamager.getName()).getStatus() == Status.LOST) {
             event.setCancelled(true);
             return;
         }
@@ -214,7 +214,7 @@ public class EntityListener implements Listener {
             return;
         }
 
-        final Arena arena = ArenaPlayer.parsePlayer(eDamagee.getName())
+        final Arena arena = ArenaPlayer.fromPlayer(eDamagee.getName())
                 .getArena();
         if (arena == null) {
             // defender no arena player => out
@@ -241,8 +241,8 @@ public class EntityListener implements Listener {
 
         boolean defTeam = false;
         boolean attTeam = false;
-        final ArenaPlayer apDefender = ArenaPlayer.parsePlayer(defender.getName());
-        final ArenaPlayer apAttacker = ArenaPlayer.parsePlayer(attacker.getName());
+        final ArenaPlayer apDefender = ArenaPlayer.fromPlayer(defender.getName());
+        final ArenaPlayer apAttacker = ArenaPlayer.fromPlayer(attacker.getName());
 
         for (ArenaTeam team : arena.getTeams()) {
             defTeam = defTeam || team.getTeamMembers().contains(
@@ -327,15 +327,15 @@ public class EntityListener implements Listener {
         final Entity eDamagee = event.getHitEntity();
 
 
-        if (eDamager instanceof Player && ArenaPlayer.parsePlayer(((Player) eDamager).getName()).getStatus() == Status.LOST) {
+        if (eDamager instanceof Player && ArenaPlayer.fromPlayer(((Player) eDamager).getName()).getStatus() == Status.LOST) {
             return;
         }
 
         if(eDamager instanceof Player && eDamagee instanceof Player) {
             final Player attacker = (Player) eDamager;
             final Player defender = (Player) eDamagee;
-            final ArenaPlayer apDefender = ArenaPlayer.parsePlayer(defender.getName());
-            final ArenaPlayer apAttacker = ArenaPlayer.parsePlayer(attacker.getName());
+            final ArenaPlayer apDefender = ArenaPlayer.fromPlayer(defender.getName());
+            final ArenaPlayer apAttacker = ArenaPlayer.fromPlayer(attacker.getName());
             final Arena arena = apDefender.getArena();
 
             if (arena == null || apAttacker.getArena() == null || apDefender.getStatus() == Status.LOST || !arena.isFightInProgress()) {
@@ -358,12 +358,12 @@ public class EntityListener implements Listener {
             return;
         }
 
-        if (ArenaPlayer.parsePlayer(entity.getName()).getStatus() == Status.LOST) {
+        if (ArenaPlayer.fromPlayer(entity.getName()).getStatus() == Status.LOST) {
             event.setCancelled(true);
             return;
         }
 
-        final Arena arena = ArenaPlayer.parsePlayer(entity.getName())
+        final Arena arena = ArenaPlayer.fromPlayer(entity.getName())
                 .getArena();
         if (arena == null) {
             // defender no arena player => out
@@ -372,7 +372,7 @@ public class EntityListener implements Listener {
 
         final Player defender = (Player) entity;
 
-        final ArenaPlayer apDefender = ArenaPlayer.parsePlayer(defender.getName());
+        final ArenaPlayer apDefender = ArenaPlayer.fromPlayer(defender.getName());
 
         if (arena.realEndRunner != null
                 || (!apDefender.getStatus().equals(Status.NULL) && !apDefender
@@ -396,7 +396,7 @@ public class EntityListener implements Listener {
             if (arena.hasEntity(event.getEntity())) {
 
                 Player player = arena.getEntityOwner(event.getEntity());
-                ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+                ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
                 if (event.getEntity().equals(player)) {
                     event.setCancelled(true);
@@ -430,7 +430,7 @@ public class EntityListener implements Listener {
             Tameable t = (Tameable) event.getEntity();
 
             if (t.isTamed()) {
-                ArenaPlayer ap = ArenaPlayer.parsePlayer(t.getOwner().getName());
+                ArenaPlayer ap = ArenaPlayer.fromPlayer(t.getOwner().getName());
                 if (ap.getArena() != null) {
                     event.setCancelled(true);
                 }
@@ -457,7 +457,7 @@ public class EntityListener implements Listener {
         ArenaPlayer shooter;
 
         try {
-            shooter = ArenaPlayer.parsePlayer(((Player) event.getEntity()
+            shooter = ArenaPlayer.fromPlayer(((Player) event.getEntity()
                     .getShooter()).getName());
         } catch (Exception e) {
             return;
@@ -481,7 +481,7 @@ public class EntityListener implements Listener {
                 debug("skipping non-player {}", e.getName());
                 continue;
             }
-            final ArenaPlayer damagee = ArenaPlayer.parsePlayer(e.getName());
+            final ArenaPlayer damagee = ArenaPlayer.fromPlayer(e.getName());
 
             if (damagee.getArena() == null || shooter.getArena() == null ||
                     (damagee.getArena() != shooter.getArena()) ||

--- a/src/main/java/net/slipcor/pvparena/listeners/InventoryListener.java
+++ b/src/main/java/net/slipcor/pvparena/listeners/InventoryListener.java
@@ -30,7 +30,7 @@ public class InventoryListener implements Listener {
     public static void onInventoryClick(final InventoryClickEvent event) {
         final Player player = (Player) event.getWhoClicked();
 
-        final Arena arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
+        final Arena arena = ArenaPlayer.fromPlayer(player).getArena();
 
         if (arena == null) {
             return;

--- a/src/main/java/net/slipcor/pvparena/listeners/PlayerListener.java
+++ b/src/main/java/net/slipcor/pvparena/listeners/PlayerListener.java
@@ -82,7 +82,7 @@ public class PlayerListener implements Listener {
             return false;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
         if ((aPlayer.getStatus() == Status.WATCH || aPlayer.getStatus() == Status.LOST) &&
                 arena.getArenaConfig().getBoolean(CFG.PERMS_SPECINTERACT)) {
@@ -117,7 +117,7 @@ public class PlayerListener implements Listener {
                 return false;
             }
         }
-        if (ArenaPlayer.parsePlayer(player.getName()).getStatus() == Status.LOST) {
+        if (ArenaPlayer.fromPlayer(player).getStatus() == Status.LOST) {
             debug(player, "cancelling because LOST");
             event.setCancelled(true);
             return true;
@@ -135,8 +135,8 @@ public class PlayerListener implements Listener {
             return;
         }
 
-        final Arena arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final Arena arena = ArenaPlayer.fromPlayer(player).getArena();
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
         if (arena == null) {
             return; // no fighting player => OUT
@@ -201,7 +201,7 @@ public class PlayerListener implements Listener {
             return;
         }
 
-        final Arena arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
+        final Arena arena = ArenaPlayer.fromPlayer(player).getArena();
         if (arena == null || player.isOp() || PVPArena.hasAdminPerms(player)
                 || PVPArena.hasCreatePerms(player, arena)) {
             return; // no fighting player => OUT
@@ -257,7 +257,7 @@ public class PlayerListener implements Listener {
 
         final Player player = (Player) event.getWhoClicked();
 
-        final Arena arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
+        final Arena arena = ArenaPlayer.fromPlayer(player).getArena();
         if (arena == null || player.isOp() || PVPArena.hasAdminPerms(player)
                 || PVPArena.hasCreatePerms(player, arena)) {
             return; // no fighting player => OUT
@@ -286,7 +286,7 @@ public class PlayerListener implements Listener {
             return;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         final Arena arena = aPlayer.getArena();
         if (arena == null) {
             return; // no fighting player => OUT
@@ -346,7 +346,7 @@ public class PlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOW)
     public void onPlayerDeath(final PlayerDeathEvent event) {
         final Player player = event.getEntity();
-        final Arena arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
+        final Arena arena = ArenaPlayer.fromPlayer(player).getArena();
         if (arena != null) {
             WorkflowManager.handlePlayerDeath(arena, player, event);
         }
@@ -369,7 +369,7 @@ public class PlayerListener implements Listener {
             cause = (EntityDamageEvent) eEvent;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         final ArenaTeam team = aPlayer.getArenaTeam();
 
         final String playerName = (team == null) ? player.getName() : team.colorizePlayer(player);
@@ -436,7 +436,7 @@ public class PlayerListener implements Listener {
 
         final Player player = (Player) event.getEntity();
 
-        final ArenaPlayer ap = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer ap = ArenaPlayer.fromPlayer(player);
 
         if (ap.getStatus() == Status.READY || ap.getStatus() == Status.LOUNGE || ap.getArena() != null && !ap.getArena().getArenaConfig().getBoolean(CFG.PLAYER_HUNGER)) {
             event.setCancelled(true);
@@ -492,7 +492,7 @@ public class PlayerListener implements Listener {
             return;
         }
 
-        arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
+        arena = ArenaPlayer.fromPlayer(player).getArena();
         if (arena == null) {
             debug(player, "returning: #4");
             ArenaManager.trySignJoin(event, player);
@@ -507,7 +507,7 @@ public class PlayerListener implements Listener {
         final boolean whyMe = arena.isFightInProgress()
                 && !arena.getGoal().allowsJoinInBattle();
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         final ArenaTeam team = aPlayer.getArenaTeam();
 
         if (aPlayer.getStatus() == Status.WATCH &&
@@ -670,7 +670,7 @@ public class PlayerListener implements Listener {
                     }
                 }
 
-                ArenaPlayer.parsePlayer(player.getName()).setStatus(
+                ArenaPlayer.fromPlayer(player).setStatus(
                         Status.FIGHT);
 
                 ArenaModuleManager.lateJoin(arena, player);
@@ -721,7 +721,7 @@ public class PlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerItemConsume(final PlayerItemConsumeEvent event) {
-        ArenaPlayer arenaPlayer = ArenaPlayer.parsePlayer(event.getPlayer().getName());
+        ArenaPlayer arenaPlayer = ArenaPlayer.fromPlayer(event.getPlayer().getName());
         if (arenaPlayer.getArena() != null && arenaPlayer.getStatus() != Status.FIGHT) {
             event.setCancelled(true);
         }
@@ -735,7 +735,7 @@ public class PlayerListener implements Listener {
             return;
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
         aPlayer.setArena(null);
         // instantiate and/or reset a player. This fixes issues with leaving
@@ -758,7 +758,7 @@ public class PlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerKicked(final PlayerKickEvent event) {
         final Player player = event.getPlayer();
-        final Arena arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
+        final Arena arena = ArenaPlayer.fromPlayer(player).getArena();
         if (arena == null) {
             return; // no fighting player => OUT
         }
@@ -768,7 +768,7 @@ public class PlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerRespawn(final PlayerRespawnEvent event) {
         final Player player = event.getPlayer();
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         // aPlayer.setArena(null);
         // instantiate and/or reset a player. This fixes issues with leaving
         // players and makes sure every player is an arenaplayer ^^
@@ -799,7 +799,7 @@ public class PlayerListener implements Listener {
             return;
         }
 
-        final Arena arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
+        final Arena arena = ArenaPlayer.fromPlayer(player).getArena();
 
         if (arena != null) {
 
@@ -821,7 +821,7 @@ public class PlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerQuit(final PlayerQuitEvent event) {
         final Player player = event.getPlayer();
-        final Arena arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
+        final Arena arena = ArenaPlayer.fromPlayer(player).getArena();
         if (arena == null) {
             return; // no fighting player => OUT
         }
@@ -947,7 +947,7 @@ public class PlayerListener implements Listener {
     public void onPlayerVelocity(final PlayerVelocityEvent event) {
         final Player player = event.getPlayer();
 
-        final Arena arena = ArenaPlayer.parsePlayer(player.getName()).getArena();
+        final Arena arena = ArenaPlayer.fromPlayer(player).getArena();
         if (arena == null) {
             return; // no fighting player or no powerups => OUT
         }
@@ -958,7 +958,7 @@ public class PlayerListener implements Listener {
     public void onPlayerVelocity(final ProjectileLaunchEvent event) {
         if (event.getEntity().getShooter() instanceof Player) {
             final Player player = (Player) event.getEntity().getShooter();
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
             final Arena arena = aPlayer.getArena();
             if (arena == null) {
                 return; // no fighting player => OUT

--- a/src/main/java/net/slipcor/pvparena/managers/InventoryManager.java
+++ b/src/main/java/net/slipcor/pvparena/managers/InventoryManager.java
@@ -64,7 +64,7 @@ public final class InventoryManager {
         final List<Material> exclude;
         final List<ItemStack> keep;
 
-        final ArenaPlayer ap = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer ap = ArenaPlayer.fromPlayer(player);
 
         boolean keepAll = false;
 

--- a/src/main/java/net/slipcor/pvparena/managers/SpawnManager.java
+++ b/src/main/java/net/slipcor/pvparena/managers/SpawnManager.java
@@ -590,7 +590,7 @@ public final class SpawnManager {
         if (!arena.hasPlayer(player)) {
             return false;
         }
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         final ArenaTeam team = aPlayer.getArenaTeam();
         if (team == null) {
             return false;

--- a/src/main/java/net/slipcor/pvparena/managers/StatisticsManager.java
+++ b/src/main/java/net/slipcor/pvparena/managers/StatisticsManager.java
@@ -17,7 +17,6 @@ import org.bukkit.entity.Player;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.util.Comparator.reverseOrder;
@@ -132,7 +131,7 @@ public final class StatisticsManager {
             debug(arena, defender, "attacker is player: " + attacker.getName());
             if (arena.hasPlayer(attacker)) {
                 debug(arena, defender, "attacker is in the arena, adding damage!");
-                final ArenaPlayer apAttacker = ArenaPlayer.parsePlayer(attacker.getName());
+                final ArenaPlayer apAttacker = ArenaPlayer.fromPlayer(attacker.getName());
                 final int maxdamage = apAttacker.getStatistics(arena).getStat(Type.MAXDAMAGE);
                 apAttacker.getStatistics(arena).incStat(Type.DAMAGE, (int) dmg);
                 if (dmg > maxdamage) {
@@ -140,7 +139,7 @@ public final class StatisticsManager {
                 }
             }
         }
-        final ArenaPlayer apDefender = ArenaPlayer.parsePlayer(defender.getName());
+        final ArenaPlayer apDefender = ArenaPlayer.fromPlayer(defender.getName());
 
         final int maxdamage = apDefender.getStatistics(arena).getStat(Type.MAXDAMAGETAKE);
         apDefender.getStatistics(arena).incStat(Type.DAMAGETAKE, (int) dmg);
@@ -254,10 +253,10 @@ public final class StatisticsManager {
                 final PAKillEvent kEvent = new PAKillEvent(arena, attacker);
                 Bukkit.getPluginManager().callEvent(kEvent);
 
-                ArenaPlayer.parsePlayer(attacker.getName()).addKill();
+                ArenaPlayer.fromPlayer(attacker.getName()).addKill();
             }
         }
-        ArenaPlayer.parsePlayer(defender.getName()).addDeath();
+        ArenaPlayer.fromPlayer(defender.getName()).addDeath();
     }
 
     public static void save() {

--- a/src/main/java/net/slipcor/pvparena/managers/TabManager.java
+++ b/src/main/java/net/slipcor/pvparena/managers/TabManager.java
@@ -37,7 +37,7 @@ public final class TabManager {
             if (PAA_Edit.activeEdits.containsKey(sender.getName())){
                 arena = PAA_Edit.activeEdits.get(sender.getName());
             } else {
-                arena = ArenaPlayer.parsePlayer(sender.getName()).getArena();
+                arena = ArenaPlayer.fromPlayer(sender.getName()).getArena();
             }
         }
 

--- a/src/main/java/net/slipcor/pvparena/managers/WorkflowManager.java
+++ b/src/main/java/net/slipcor/pvparena/managers/WorkflowManager.java
@@ -145,7 +145,7 @@ public class WorkflowManager {
             team = arena.getTeam(args[0]);
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
         ArenaModuleManager.choosePlayerTeam(arena, player, team.getColoredName());
 
@@ -234,7 +234,7 @@ public class WorkflowManager {
             }
             if (arena.getArenaConfig().getBoolean(CFG.PLAYER_REFILLFORKILL)) {
                 InventoryManager.clearInventory(player.getKiller());
-                ArenaPlayer.parsePlayer(player.getKiller().getName()).getArenaClass().equip(player.getKiller());
+                ArenaPlayer.fromPlayer(player.getKiller().getName()).getArenaClass().equip(player.getKiller());
             }
             if (arena.getArenaConfig().getItems(CFG.PLAYER_ITEMSONKILL) != null) {
                 ItemStack[] items = arena.getArenaConfig().getItems(CFG.PLAYER_ITEMSONKILL);
@@ -245,7 +245,7 @@ public class WorkflowManager {
                 }
             }
             if (arena.getArenaConfig().getBoolean(CFG.USES_TELEPORTONKILL)) {
-                SpawnManager.respawn(arena, ArenaPlayer.parsePlayer(player.getKiller().getName()), null);
+                SpawnManager.respawn(arena, ArenaPlayer.fromPlayer(player.getKiller().getName()), null);
             }
         }
 
@@ -266,7 +266,7 @@ public class WorkflowManager {
                     event.setDroppedExp(exp);
                 }
             }
-            final ArenaTeam respawnTeam = ArenaPlayer.parsePlayer(
+            final ArenaTeam respawnTeam = ArenaPlayer.fromPlayer(
                     player.getName()).getArenaTeam();
 
             if (arena.getArenaConfig().getBoolean(CFG.USES_DEATHMESSAGES)) {
@@ -289,7 +289,7 @@ public class WorkflowManager {
                 event.getDrops().clear();
             }
 
-            handleRespawn(arena, ArenaPlayer.parsePlayer(player.getName()), returned);
+            handleRespawn(arena, ArenaPlayer.fromPlayer(player), returned);
 
 
             arena.getGoal().parsePlayerDeath(player, player.getLastDamageCause());
@@ -307,7 +307,7 @@ public class WorkflowManager {
         ArenaModuleManager.parsePlayerDeath(arena, player,
                 player.getLastDamageCause());
 
-        if (!arena.getArenaConfig().getBoolean(CFG.PLAYER_DROPSINVENTORY) || !ArenaPlayer.parsePlayer(player.getName()).mayDropInventory()) {
+        if (!arena.getArenaConfig().getBoolean(CFG.PLAYER_DROPSINVENTORY) || !ArenaPlayer.fromPlayer(player).mayDropInventory()) {
             event.getDrops().clear();
         }
         if (doesRespawn

--- a/src/main/java/net/slipcor/pvparena/modules/BattlefieldJoin.java
+++ b/src/main/java/net/slipcor/pvparena/modules/BattlefieldJoin.java
@@ -61,7 +61,7 @@ public class BattlefieldJoin extends ArenaModule {
             throw new GameplayException(Language.parse(this.arena, MSG.ERROR_DISABLED));
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
         if (aPlayer.getArena() != null) {
             debug(aPlayer.getArena(), player, this.getName());
@@ -75,7 +75,7 @@ public class BattlefieldJoin extends ArenaModule {
     @Override
     public void commitJoin(final Player sender, final ArenaTeam team) {
         // standard join --> lounge
-        final ArenaPlayer arenaPlayer = ArenaPlayer.parsePlayer(sender.getName());
+        final ArenaPlayer arenaPlayer = ArenaPlayer.fromPlayer(sender.getName());
         arenaPlayer.setLocation(new PALocation(arenaPlayer.getPlayer().getLocation()));
 
         arenaPlayer.setArena(this.arena);

--- a/src/main/java/net/slipcor/pvparena/modules/StandardLounge.java
+++ b/src/main/java/net/slipcor/pvparena/modules/StandardLounge.java
@@ -92,7 +92,7 @@ public class StandardLounge extends ArenaModule {
             throw new GameplayException(Language.parse(this.arena, MSG.ERROR_DISABLED));
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
         if (aPlayer.getArena() != null) {
             debug(aPlayer.getArena(), player, this.getName());
@@ -129,7 +129,7 @@ public class StandardLounge extends ArenaModule {
     @Override
     public void commitJoin(final Player sender, final ArenaTeam team) {
         // standard join --> lounge
-        final ArenaPlayer player = ArenaPlayer.parsePlayer(sender.getName());
+        final ArenaPlayer player = ArenaPlayer.fromPlayer(sender.getName());
         player.setLocation(new PALocation(player.getPlayer().getLocation()));
 
         // ArenaPlayer.prepareInventory(arena, ap.getPlayer());

--- a/src/main/java/net/slipcor/pvparena/modules/StandardSpectate.java
+++ b/src/main/java/net/slipcor/pvparena/modules/StandardSpectate.java
@@ -49,7 +49,7 @@ public class StandardSpectate extends ArenaModule {
 
     @Override
     public boolean handleSpectate(Player player) throws GameplayException {
-        final ArenaPlayer arenaPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer arenaPlayer = ArenaPlayer.fromPlayer(player);
         if (arenaPlayer.getArena() != null) {
             throw new GameplayException(Language.parse(MSG.ERROR_ARENA_ALREADY_PART_OF, arenaPlayer.getArena().getName()));
         }
@@ -60,7 +60,7 @@ public class StandardSpectate extends ArenaModule {
     @Override
     public void commitSpectate(final Player player) {
         // standard join --> lounge
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         aPlayer.setLocation(new PALocation(player.getLocation()));
 
         aPlayer.setArena(this.arena);

--- a/src/main/java/net/slipcor/pvparena/modules/WarmupJoin.java
+++ b/src/main/java/net/slipcor/pvparena/modules/WarmupJoin.java
@@ -65,7 +65,7 @@ public class WarmupJoin extends ArenaModule {
             throw new GameplayException(Language.parse(this.arena, MSG.ERROR_DISABLED));
         }
 
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
 
         if (this.getPlayerSet().contains(aPlayer)) {
             return false;
@@ -83,13 +83,13 @@ public class WarmupJoin extends ArenaModule {
 
     @Override
     public void commitJoin(final Player sender, final ArenaTeam team) {
-        new ArenaWarmupRunnable(this.arena, ArenaPlayer.parsePlayer(sender.getName()), team.getName(), false, this.arena.getArenaConfig().getInt(CFG.TIME_WARMUPCOUNTDOWN));
+        new ArenaWarmupRunnable(this.arena, ArenaPlayer.fromPlayer(sender.getName()), team.getName(), false, this.arena.getArenaConfig().getInt(CFG.TIME_WARMUPCOUNTDOWN));
         this.announced = true;
     }
 
     @Override
     public void commitSpectate(final Player sender) {
-        new ArenaWarmupRunnable(this.arena, ArenaPlayer.parsePlayer(sender.getName()), null, true, this.arena.getArenaConfig().getInt(CFG.TIME_WARMUPCOUNTDOWN));
+        new ArenaWarmupRunnable(this.arena, ArenaPlayer.fromPlayer(sender.getName()), null, true, this.arena.getArenaConfig().getInt(CFG.TIME_WARMUPCOUNTDOWN));
     }
 
     @Override
@@ -113,6 +113,6 @@ public class WarmupJoin extends ArenaModule {
 
     @Override
     public void parsePlayerLeave(final Player player, final ArenaTeam team) {
-        this.getPlayerSet().remove(ArenaPlayer.parsePlayer(player.getName()));
+        this.getPlayerSet().remove(ArenaPlayer.fromPlayer(player));
     }
 }

--- a/src/main/java/net/slipcor/pvparena/regions/ArenaRegion.java
+++ b/src/main/java/net/slipcor/pvparena/regions/ArenaRegion.java
@@ -119,7 +119,7 @@ public class ArenaRegion {
             // - player has admin perms
             // - player has wand in hand
             debug(arena, player, "modify&adminperms&wand");
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
             if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
                 aPlayer.setSelection(event.getClickedBlock().getLocation(), false);
                 arena.msg(player, Language.parse(arena, MSG.REGION_POS1));
@@ -466,12 +466,12 @@ public class ArenaRegion {
         Arena.pmsg(player, Language.parse(this.arena, MSG.NOTICE_YOU_DEATH));
         ArenaGoal goal = this.arena.getGoal();
         if (goal.getName().endsWith("DeathMatch")) {
-            if (goal.getLifeMap().containsKey(arenaPlayer.getName())) {
-                final int lives = goal.getLifeMap().get(arenaPlayer.getName()) + 1;
-                goal.getLifeMap().put(arenaPlayer.getName(), lives);
-            } else if (goal.getLifeMap().containsKey(arenaPlayer.getArenaTeam().getName())) {
-                final int lives = goal.getLifeMap().get(arenaPlayer.getArenaTeam().getName()) + 1;
-                goal.getLifeMap().put(arenaPlayer.getArenaTeam().getName(), lives);
+            if (goal.getPlayerLifeMap().containsKey(arenaPlayer.getPlayer())) {
+                final int lives = goal.getPlayerLifeMap().get(arenaPlayer.getPlayer()) + 1;
+                goal.getPlayerLifeMap().put(arenaPlayer.getPlayer(), lives);
+            } else if (goal.getTeamLifeMap().containsKey(arenaPlayer.getArenaTeam())) {
+                final int lives = goal.getTeamLifeMap().get(arenaPlayer.getArenaTeam()) + 1;
+                goal.getTeamLifeMap().put(arenaPlayer.getArenaTeam(), lives);
             }
         }
 

--- a/src/main/java/net/slipcor/pvparena/runnables/ArenaRunnable.java
+++ b/src/main/java/net/slipcor/pvparena/runnables/ArenaRunnable.java
@@ -143,7 +143,7 @@ public abstract class ArenaRunnable extends BukkitRunnable {
         }
 
         if (Bukkit.getPlayer(this.sPlayer) != null) {
-            final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(this.sPlayer);
+            final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(this.sPlayer);
             if (aPlayer.getArena() == null) {
                 Arena.pmsg(Bukkit.getPlayer(this.sPlayer), message);
             } else {

--- a/src/main/java/net/slipcor/pvparena/runnables/CircleParticleRunnable.java
+++ b/src/main/java/net/slipcor/pvparena/runnables/CircleParticleRunnable.java
@@ -1,6 +1,7 @@
 package net.slipcor.pvparena.runnables;
 
 import net.slipcor.pvparena.arena.Arena;
+import net.slipcor.pvparena.arena.ArenaTeam;
 import net.slipcor.pvparena.classes.PABlock;
 import net.slipcor.pvparena.core.ColorUtils;
 import net.slipcor.pvparena.core.Config;
@@ -10,12 +11,12 @@ import org.bukkit.*;
 import java.util.Map;
 
 public class CircleParticleRunnable implements Runnable {
-    private final Map<Location, String> flagMap;
+    private final Map<Location, ArenaTeam> flagMap;
     private final Arena arena;
     private final double radius;
     private int i = 0;
 
-    public CircleParticleRunnable(Arena arena, Config.CFG config, Map<Location, String> flagMap) {
+    public CircleParticleRunnable(Arena arena, Config.CFG config, Map<Location, ArenaTeam> flagMap) {
         this.arena = arena;
         this.flagMap = flagMap;
         this.radius = arena.getArenaConfig().getInt(config, 3);
@@ -23,7 +24,7 @@ public class CircleParticleRunnable implements Runnable {
 
     private Color getDustColor(Location flagLocation) {
         if(this.flagMap.containsKey(flagLocation)) {
-            ChatColor teamColor = this.arena.getTeam(this.flagMap.get(flagLocation)).getColor();
+            ChatColor teamColor = this.flagMap.get(flagLocation).getColor();
             return ColorUtils.getDyeColorFromChatColor(teamColor).getColor();
         }
         return Color.WHITE;

--- a/src/main/java/net/slipcor/pvparena/runnables/InventoryRefillRunnable.java
+++ b/src/main/java/net/slipcor/pvparena/runnables/InventoryRefillRunnable.java
@@ -35,7 +35,7 @@ public class InventoryRefillRunnable implements Runnable {
     private final boolean refill;
 
     public InventoryRefillRunnable(final Arena arena, final Player player, final List<ItemStack> itemList) {
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(player);
         if (arena == null && aPlayer.getArena() == null) {
             this.player = null;
             this.arena = null;
@@ -77,7 +77,7 @@ public class InventoryRefillRunnable implements Runnable {
 
     @Override
     public void run() {
-        final ArenaPlayer aPlayer = ArenaPlayer.parsePlayer(this.player.getName());
+        final ArenaPlayer aPlayer = ArenaPlayer.fromPlayer(this.player.getName());
         debug(this.arena, "refilling " + this.player.getName());
         if (aPlayer.getStatus() == Status.FIGHT) {
             if (aPlayer.hasCustomClass() && !this.arena.getArenaConfig().getBoolean(CFG.PLAYER_REFILLCUSTOMINVENTORY) || !this.arena.getArenaConfig().getBoolean(CFG.PLAYER_REFILLINVENTORY)) {


### PR DESCRIPTION
- Use of ArenaPlayer instead of getName()
- Use of ArenaTeam instead of getName()
- Refacto life maps
- Rename all ap, at etc to ArenaPlayer, ArenaTeam etc. (to have intellij "copied code warn" working)