### PR TITLE
fix NPE on painting break

### DIFF
--- a/src/net/slipcor/pvparena/listeners/BlockListener.java
+++ b/src/net/slipcor/pvparena/listeners/BlockListener.java
@@ -512,11 +512,11 @@ public class BlockListener implements Listener {
             return;
         }
         if (arena == null) {
-            DEBUG.i("painting break inside the arena");
-        } else {
-            arena.getDebugger().i("painting break inside the arena");
+            DEBUG.i("painting break outside an arena");
+            return;
         }
-        ArenaModuleManager.onPaintingBreak(arena, event.getEntity(), event
-                .getEntity().getType());
+
+        arena.getDebugger().i("painting break inside an arena");
+        ArenaModuleManager.onPaintingBreak(arena, event.getEntity(), event.getEntity().getType());
     }
 }


### PR DESCRIPTION
```
[16:20:52 ERROR]: Could not pass event HangingBreakEvent to pvparena v1.15.2-SNAPSHOT-b7
java.lang.NullPointerException: null
at net.slipcor.pvparena.loadables.ArenaModuleManager.onPaintingBreak(ArenaModuleManager.java:195) ~[?:?]
at net.slipcor.pvparena.listeners.BlockListener.onBlockBreak(BlockListener.java:519) ~[?:?]
at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor824.execute(Unknown Source) ~[?:?]
at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.16.5.jar:git-Paper-664]
at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.16.5.jar:git-Paper-664]
at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.16.5.jar:git-Paper-664]
at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:607) ~[patched_1.16.5.jar:git-Paper-664]
at net.minecraft.server.v1_16_R3.EntityHanging.tick(EntityHanging.java:138) ~[patched_1.16.5.jar:git-Paper-664]
at net.minecraft.server.v1_16_R3.WorldServer.entityJoinedWorld(WorldServer.java:960) ~[patched_1.16.5.jar:git-Paper-664]
at net.minecraft.server.v1_16_R3.World.a(World.java:946) ~[patched_1.16.5.jar:git-Paper-664]
at net.minecraft.server.v1_16_R3.WorldServer.doTick(WorldServer.java:646) ~[patched_1.16.5.jar:git-Paper-664]
at net.minecraft.server.v1_16_R3.MinecraftServer.b(MinecraftServer.java:1487) ~[patched_1.16.5.jar:git-Paper-664]
at net.minecraft.server.v1_16_R3.DedicatedServer.b(DedicatedServer.java:419) ~[patched_1.16.5.jar:git-Paper-664]
at net.minecraft.server.v1_16_R3.MinecraftServer.a(MinecraftServer.java:1339) ~[patched_1.16.5.jar:git-Paper-664]
at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1127) ~[patched_1.16.5.jar:git-Paper-664]
at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:290) ~[patched_1.16.5.jar:git-Paper-664]
at java.lang.Thread.run(Thread.java:834) [?:?]
```