### PR TITLE
Fix reloading of classes.yml and improve exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dependency-reduced-pom.xml
 
 /bin/
 /.settings/
+/.classpath
+/.project

--- a/src/net/slipcor/pvparena/commands/PAA_ReloadAll.java
+++ b/src/net/slipcor/pvparena/commands/PAA_ReloadAll.java
@@ -2,6 +2,7 @@ package net.slipcor.pvparena.commands;
 
 import net.slipcor.pvparena.PVPArena;
 import net.slipcor.pvparena.arena.Arena;
+import net.slipcor.pvparena.arena.ArenaClass;
 import net.slipcor.pvparena.core.Help;
 import net.slipcor.pvparena.core.Help.HELP;
 import net.slipcor.pvparena.core.Language;
@@ -56,6 +57,7 @@ public class PAA_ReloadAll extends AbstractGlobalCommand {
             scmd.commit(a, sender, emptyArray);
         }
 
+        ArenaClass.addGlobalClasses(); // reload classes.yml
         ArenaManager.load_arenas();
         if (config.getBoolean("use_shortcuts") || config.getBoolean("only_shortcuts")) {
             ArenaManager.readShortcuts(config.getConfigurationSection("shortcuts"));

--- a/src/net/slipcor/pvparena/managers/ConfigurationManager.java
+++ b/src/net/slipcor/pvparena/managers/ConfigurationManager.java
@@ -129,34 +129,7 @@ public final class ConfigurationManager {
 
         if (config.get("classitems") == null) {
             if (PVPArena.instance.getConfig().get("classitems") == null) {
-                config.addDefault("classitems.Ranger.items",
-                        Utils.getItemStacksFromMaterials(Material.BOW, Material.ARROW));
-                config.addDefault("classitems.Ranger.offhand",
-                        Utils.getItemStacksFromMaterials(Material.AIR));
-                config.addDefault("classitems.Ranger.armor",
-                        Utils.getItemStacksFromMaterials(Material.LEATHER_HELMET, Material.LEATHER_CHESTPLATE, Material.LEATHER_LEGGINGS, Material.LEATHER_BOOTS));
-
-                config.addDefault("classitems.Swordsman.items",
-                        Utils.getItemStacksFromMaterials(Material.DIAMOND_SWORD));
-                config.addDefault("classitems.Swordsman.offhand",
-                        Utils.getItemStacksFromMaterials(Material.AIR));
-                config.addDefault("classitems.Swordsman.armor",
-                        Utils.getItemStacksFromMaterials(Material.IRON_HELMET, Material.IRON_CHESTPLATE, Material.IRON_LEGGINGS, Material.IRON_BOOTS));
-
-                config.addDefault("classitems.Tank.items",
-                        Utils.getItemStacksFromMaterials(Material.STONE_SWORD));
-                config.addDefault("classitems.Tank.offhand",
-                        Utils.getItemStacksFromMaterials(Material.AIR));
-                config.addDefault("classitems.Tank.armor",
-                        Utils.getItemStacksFromMaterials(Material.DIAMOND_HELMET, Material.DIAMOND_CHESTPLATE, Material.DIAMOND_LEGGINGS, Material.DIAMOND_BOOTS));
-
-                config.addDefault("classitems.Pyro.items",
-                        Utils.getItemStacksFromMaterials(Material.FLINT_AND_STEEL, Material.TNT, Material.TNT, Material.TNT));
-                config.addDefault("classitems.Pyro.offhand",
-                        Utils.getItemStacksFromMaterials(Material.AIR));
-                config.addDefault("classitems.Pyro.armor",
-                        Utils.getItemStacksFromMaterials(Material.LEATHER_HELMET, Material.LEATHER_CHESTPLATE, Material.LEATHER_LEGGINGS, Material.LEATHER_BOOTS));
-
+                config.addDefault("classitems", generateDefaultClasses());
             }
         }
 
@@ -198,8 +171,8 @@ public final class ConfigurationManager {
         ArenaClass.addGlobalClasses(arena);
         for (final Map.Entry<String, Object> stringObjectEntry1 : classes.entrySet()) {
             ItemStack[] items;
-            ItemStack offHand = new ItemStack(Material.AIR, 1);
-            ItemStack[] armors = new ItemStack[]{new ItemStack(Material.AIR, 1)};
+            ItemStack offHand;
+            ItemStack[] armors;
 
             try {
                 items = getItemStacksFromConfig(config.getList("classitems."+stringObjectEntry1.getKey()+".items"));
@@ -301,6 +274,36 @@ public final class ConfigurationManager {
 
         arena.setPrefix(cfg.getString(CFG.GENERAL_PREFIX));
         return true;
+    }
+
+    public static Map<String, Object> generateDefaultClasses() {
+        Map<String, Object> classItems = new HashMap<>();
+
+        classItems.put("Ranger", new HashMap<String, List<?>>() {{
+            put("items", Utils.getItemStacksFromMaterials(Material.BOW, Material.ARROW));
+            put("offhand", Utils.getItemStacksFromMaterials(Material.AIR));
+            put("armor", Utils.getItemStacksFromMaterials(Material.LEATHER_HELMET, Material.LEATHER_CHESTPLATE, Material.LEATHER_LEGGINGS, Material.LEATHER_BOOTS));
+        }});
+
+        classItems.put("Swordsman", new HashMap<String, List<?>>() {{
+            put("items", Utils.getItemStacksFromMaterials(Material.DIAMOND_SWORD));
+            put("offhand", Utils.getItemStacksFromMaterials(Material.AIR));
+            put("armor", Utils.getItemStacksFromMaterials(Material.LEATHER_HELMET, Material.LEATHER_CHESTPLATE, Material.LEATHER_LEGGINGS, Material.LEATHER_BOOTS));
+        }});
+
+        classItems.put("Tank", new HashMap<String, List<?>>() {{
+            put("items", Utils.getItemStacksFromMaterials(Material.STONE_SWORD));
+            put("offhand", Utils.getItemStacksFromMaterials(Material.AIR));
+            put("armor", Utils.getItemStacksFromMaterials(Material.DIAMOND_HELMET, Material.DIAMOND_CHESTPLATE, Material.DIAMOND_LEGGINGS, Material.DIAMOND_BOOTS));
+        }});
+
+        classItems.put("Pyro", new HashMap<String, List<?>>() {{
+            put("items", Utils.getItemStacksFromMaterials(Material.FLINT_AND_STEEL, Material.TNT, Material.TNT, Material.TNT));
+            put("offhand", Utils.getItemStacksFromMaterials(Material.AIR));
+            put("armor", Utils.getItemStacksFromMaterials(Material.LEATHER_HELMET, Material.LEATHER_CHESTPLATE, Material.LEATHER_LEGGINGS, Material.LEATHER_BOOTS));
+        }});
+
+        return classItems;
     }
 
     /**


### PR DESCRIPTION
Main purpose of this PR is to add one line to `reload` command code that makes it also reload classes.yml. Until now you needed to restart the server for any changes to take effect. Tested and it just works.

Additionaly, I've looked into the code that loads that file and improved exception handling. In classes.yml you can have `classes` and `classchests` as in arena configs. Here, for the `classchests` part, it was coded so that if there were any problems with it, it would just silently fail. I fixed it and added an error message there.

You can test it with a file like:

```
classes:
  sword:
    items:
    - type: STONE_SWORD
    offhand:
    - type: AIR
    armor:
    - type: GOLDEN_HELMET
    - type: GOLDEN_CHESTPLATE
    - type: GOLDEN_LEGGINGS
    - type: GOLDEN_BOOTS
  bow:
    items:
    - type: BOW
    - type: ARROW
      amount: 64
    offhand:
    - type: AIR
    armor:
    - type: IRON_HELMET
    - type: IRON_CHESTPLATE
    - type: IRON_LEGGINGS
    - type: IRON_BOOTS
classchests:
  bow: world:285,64,-245
```

If there's no chest at 285, 64, -245, you'll get `[PVP Arena] [classes.yml] Error while parsing location of classchest, skipping: bow`

And finally I added two files to .gitignore that are put into the root directory by VS Code and Eclipse.

To do:
- make the default classes appear only if there are no classes defined in classes.yml
- describe that file in the docs

WARNING
This is literally the first code I ever wrote in Java, so don't ever try to assume that I've done anything correctly :P