### PR TITLE
Add error specially for the world when loading region

### DIFF
--- a/src/main/java/net/slipcor/pvparena/core/Config.java
+++ b/src/main/java/net/slipcor/pvparena/core/Config.java
@@ -987,12 +987,17 @@ public class Config {
         final Integer flags = parseInteger(parts[8]);
         final Integer prots = parseInteger(parts[9]);
 
-        if (Bukkit.getWorld(parts[0]) == null || x1 == null || y1 == null
+        if (Bukkit.getWorld(parts[0]) == null) {
+            PVPArena.getInstance().getLogger().severe(String.format("%s caused an error while loading region %s",
+                    arena.getName(), regionName));
+            throw new IllegalArgumentException(String.format("World %s not recognized. Is it loaded ?", parts[0]));
+        }
+
+        if (x1 == null || y1 == null
                 || z1 == null || x2 == null || y2 == null || z2 == null
                 || flags == null || prots == null) {
-            PVPArena.getInstance().getLogger().severe(arena.getName() + " caused an error while loading region " + regionName);
-            throw new IllegalArgumentException(
-                    "Some of the parsed values are null!");
+            PVPArena.getInstance().getLogger().severe( String.format("%s caused an error while loading region %s", arena.getName(), regionName));
+            throw new IllegalArgumentException("Some of the parsed values are null!");
         }
 
         final PABlockLocation[] l = {new PABlockLocation(parts[0], x1, y1, z1),


### PR DESCRIPTION
Better log when world is not recognized (ie loaded by spigot) (And it's not a value parsing problem)