### PR TITLE
Fix missing negation in hasExplicitClassPerm()

### DIFF
--- a/src/net/slipcor/pvparena/commands/PAG_Arenaclass.java
+++ b/src/net/slipcor/pvparena/commands/PAG_Arenaclass.java
@@ -85,7 +85,7 @@ public class PAG_Arenaclass extends AbstractArenaCommand {
             return;
         }
 
-        if (PermissionManager.hasExplicitClassPerm(sender, arena, aClass)) {
+        if (!PermissionManager.hasExplicitClassPerm(sender, arena, aClass)) {
             arena.msg(sender,
                     Language.parse(arena, MSG.ERROR_NOPERM_CLASS, aClass.getName()));
             return;


### PR DESCRIPTION
Fix bug introduced by recent commit (#121) that makes a player unable to choose a class if he HAS permission or permission isn't needed at all. 