### PR TITLE
Fix behavior of /pa class with single argument

### DIFF
--- a/lang/lang_en.yml
+++ b/lang/lang_en.yml
@@ -110,6 +110,7 @@ nulang:
       full: The class &a%1%&r is full!
       notenoughexp: You don't have enough EXP to choose &a%1%&r!
       notfound: 'Class not found: &a%1%&r'
+      notgiven: 'No class was given!'
     cmdblocked: '&cCommand blocked: %1%'
     invalidcmd: Invalid command (%1%)
     unknowncmd: Unknown command

--- a/src/net/slipcor/pvparena/core/Language.java
+++ b/src/net/slipcor/pvparena/core/Language.java
@@ -127,6 +127,7 @@ public final class Language {
         ERROR_CLASS_FULL("nulang.error.class.full", "The class &a%1%&r is full!"),
         ERROR_CLASS_NOTENOUGHEXP("nulang.error.class.notenoughexp", "You don't have enough EXP to choose &a%1%&r!"),
         ERROR_CLASS_NOT_FOUND("nulang.error.class.notfound", "Class not found: &a%1%&r"),
+        ERROR_CLASS_NOT_GIVEN("nulang.error.class.notgiven", "No class was given!"),
         ERROR_COMMAND_BLOCKED("nulang.error.cmdblocked", "&cCommand blocked: %1%"),
         ERROR_COMMAND_INVALID("nulang.error.invalidcmd", "Invalid command: %1%"),
         ERROR_COMMAND_UNKNOWN("nulang.error.unknowncmd", "Unknown command"),


### PR DESCRIPTION
Behavior of this command was that if it had only 1 arg (load/save/remove) it would exit the edit mode (strange choice) by removing the player from an arena. And it was done in a buggy way, so that doing so would silently break the whole plugin, preventing it from restarting or doing anything (then endless stacktraces would appear in the console).

I've fixed it so that when you run `/pa class save|remove|load` without second arg, it will save/remove/(re)load the class that you've just loaded, which is imo a common expectation. In case of `/pa class load` when no class was loaded before, you will get a new error message "No class was given!" (`MSG.ERROR_CLASS_NOT_GIVEN`). Also, now the code is more readable.