### PR TITLE
Fix player not being teleported back from arena after quitting the game

### DIFF
--- a/src/net/slipcor/pvparena/arena/Arena.java
+++ b/src/net/slipcor/pvparena/arena/Arena.java
@@ -1570,6 +1570,9 @@ public class Arena {
             Bukkit.getScheduler().runTaskLater(PVPArena.instance, runLater, cfg.getInt(CFG.TIME_RESETDELAY) * 20);
         } else if (PVPArena.instance.isShuttingDown()) {
             runLater.run();
+        } else if (aPlayer.isQuitting()) {
+            // if we wait when teleporting a player when he's quitting, the teleport will fail
+            runLater.run();
         } else {
             // Waiting two ticks in order to avoid player death bug
             Bukkit.getScheduler().runTaskLater(PVPArena.instance, runLater, 2);

--- a/src/net/slipcor/pvparena/arena/ArenaPlayer.java
+++ b/src/net/slipcor/pvparena/arena/ArenaPlayer.java
@@ -51,6 +51,8 @@ public class ArenaPlayer {
     private boolean teleporting;
     private boolean mayDropInventory;
 
+    // mark if the player is quitting for early teleport
+    private boolean quitting; 
     private Boolean flying;
 
     private Arena arena;
@@ -586,6 +588,10 @@ public class ArenaPlayer {
         return telePass;
     }
 
+    public boolean isQuitting() {
+        return quitting;
+    }
+
     public boolean isIgnoringAnnouncements() {
         return ignoreAnnouncements;
     }
@@ -698,6 +704,7 @@ public class ArenaPlayer {
         }
 
         telePass = false;
+        quitting = false;
 
         if (state != null) {
             state.reset();
@@ -842,6 +849,10 @@ public class ArenaPlayer {
 
     public void setTeleporting(final boolean isTeleporting) {
         teleporting = isTeleporting;
+    }
+
+    public void setQuitting(final boolean isQuitting) {
+        quitting = isQuitting;
     }
 
     public void showBloodParticles() {

--- a/src/net/slipcor/pvparena/listeners/PlayerListener.java
+++ b/src/net/slipcor/pvparena/listeners/PlayerListener.java
@@ -834,6 +834,8 @@ public class PlayerListener implements Listener {
         if (arena == null) {
             return; // no fighting player => OUT
         }
+        // must rememeber that they're quitting because then the teleport can't wait
+        ArenaPlayer.parsePlayer(player.getName()).setQuitting(true);
         arena.playerLeave(player, CFG.TP_EXIT, false, true, false);
     }
 


### PR DESCRIPTION
On my (mostly survival) server I have an inaccessible arena, which you can enter only by `/pa arena` and leave by `/pa leave`. When you're inside it and you quit the game, you become locked, because teleporting players leaving an arena is for some reason ("in order to avoid player death bug") postponed by 2 ticks. After these two ticks there's no player to teleport, so when the player comes back, he's still inside the arena (and, on my server, can't leave it).

I've implemented some workaround, by adding `ArenaPlayer.quitting` property, which, if true, allows to bypass that 2 tick wait time.

DISCLAIMER: Editing this plugin is literally the first thing I've ever done in Java, and also the first thing I touched which has so many objects, so expect silly mistakes and bad object code 😉